### PR TITLE
use generate Maybe function in flatMap of ListM

### DIFF
--- a/app/src/main/java/net/petitviolet/monad_example/MainActivity.java
+++ b/app/src/main/java/net/petitviolet/monad_example/MainActivity.java
@@ -140,6 +140,13 @@ public class MainActivity extends AppCompatActivity {
         Log.d(TAG, "State -> " + result.toString());
     }
 
+    private void combineMaybeListM() {
+        ListM.of(1, 2, 3, 4, 5)
+                .map(i -> i * 2)
+                .bindMaybe(Maybe::of)
+                .foreach(System.out::println);
+    }
+
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         // Inflate the menu; this adds items to the action bar if it is present.

--- a/monad/src/main/java/net/petitviolet/monad/list/ListM.java
+++ b/monad/src/main/java/net/petitviolet/monad/list/ListM.java
@@ -192,6 +192,17 @@ public class ListM<A> implements List<A> {
         return result;
     }
 
+    public <B> ListM<B> bindMaybe(Function.F1<? super A, Maybe<B>> func) {
+        ListM<B> result = new ListM<>();
+        for (A item : this) {
+            Maybe<B> b = func.invoke(item);
+            if (b.isPresent()) {
+                result.add(b.get());
+            }
+        }
+        return result;
+    }
+
     public <B> ListM<B> flatMap(Function.F1<? super A, ? extends ListM<B>> func) {
         // use flatMap is not effective from the viewpoint of performance
 //        return flatMap(new Function.F1<A, ListM<B>>() {

--- a/monad/src/test/java/net/petitviolet/monad/list/ListMTest.java
+++ b/monad/src/test/java/net/petitviolet/monad/list/ListMTest.java
@@ -6,17 +6,9 @@ import net.petitviolet.monad.maybe.Maybe;
 
 import org.junit.Test;
 
-import java.lang.Boolean;
-import java.lang.Integer;
-import java.lang.Override;
-import java.lang.String;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import dalvik.annotation.TestTargetClass;
-
-import static org.junit.Assert.*;
 
 /**
  * Test cases for ListM(ArrayListM)
@@ -120,6 +112,7 @@ public class ListMTest {
     public void testEqualsFalseType() {
         assert mListM.equals(Arrays.asList("a", "bb", "ccc")) == false;
     }
+
     @Test
     public void testEqualsFalseType2() {
         assert mListM.equals(1) == false;
@@ -149,5 +142,22 @@ public class ListMTest {
             }
         });
         assert result == 6;
+    }
+
+    @Test
+    public void testBindMaybe() {
+        ListM<Integer> result = ListM.of(1, 2, 3, 4, 5)
+                .map(new Function.F1<Integer, Integer>() {
+                    @Override
+                    public Integer invoke(Integer integer) {
+                        return integer * 2;
+                    }
+                }).bindMaybe(new Function.F1<Integer, Maybe<Integer>>() {
+                    @Override
+                    public Maybe<Integer> invoke(Integer integer) {
+                        return Maybe.of(integer);
+                    }
+                });
+        assert result.equals(ListM.of(2, 4, 6, 8, 10)) == true;
     }
 }


### PR DESCRIPTION
ListM should be enabled to `flatMap` with function of `A -> Maybe<B>`.
I think that if `Monad` Interface implemented by `Maybe` and `ListM`, a signature of above function was `A -> Monad<B>`, and `flatMap` can invoke easily.
However, i do not do that for keeping type detection work properly, and other reasones.
